### PR TITLE
Improve matching by ignoring spaces & Fix processLoop

### DIFF
--- a/src/extractor.ts
+++ b/src/extractor.ts
@@ -2,43 +2,19 @@ import Label from "./types/label";
 import Actor from "./types/actor";
 import Studio from "./types/studio";
 
-// Calculate token permutation in string
-// "a test string"
-// -> ["a", "test", "string", "a test", "test string", "a test string"]
-export function tokenPerms(str: string) {
-  const tokens = str
-    .toLowerCase()
-    .replace(/[^a-zA-Z0-9']/g, " ")
-    .split(" ")
-    .filter(Boolean);
-  const perms = [...tokens];
-
-  if (tokens.length <= 1) return perms;
-
-  for (let len = 2; len <= tokens.length; len++) {
-    for (let i = 0; i <= tokens.length - len; i++) {
-      const cat = [] as string[];
-      for (let j = 0; j < len; j++) {
-        cat.push(tokens[i + j]);
-      }
-      perms.push(cat.join(" "));
-    }
-  }
-
-  return perms;
+export function stripStr(str: string) {
+  return str.toLowerCase().replace(/[^a-zA-Z0-9']/g, "");
 }
 
 // Returns IDs of extracted labels
 export async function extractLabels(str: string) {
-  const perms = tokenPerms(str);
-
   const foundLabels = [] as string[];
   const allLabels = await Label.getAll();
 
   allLabels.forEach(label => {
     if (
-      perms.includes(label.name.toLowerCase()) ||
-      label.aliases.some(alias => perms.includes(alias.toLowerCase()))
+      stripStr(str).includes(stripStr(label.name)) ||
+      label.aliases.some(alias => stripStr(str).includes(stripStr(alias)))
     ) {
       foundLabels.push(label._id);
     }
@@ -48,15 +24,13 @@ export async function extractLabels(str: string) {
 
 // Returns IDs of extracted actors
 export async function extractActors(str: string) {
-  const perms = tokenPerms(str);
-
   const foundActors = [] as string[];
   const allActors = await Actor.getAll();
 
   allActors.forEach(actor => {
     if (
-      perms.includes(actor.name.toLowerCase()) ||
-      actor.aliases.some(alias => perms.includes(alias.toLowerCase()))
+      stripStr(str).includes(stripStr(actor.name)) ||
+      actor.aliases.some(alias => stripStr(str).includes(stripStr(alias)))
     ) {
       foundActors.push(actor._id);
     }
@@ -66,13 +40,11 @@ export async function extractActors(str: string) {
 
 // Returns IDs of extracted studios
 export async function extractStudios(str: string) {
-  const perms = tokenPerms(str);
-
   const foundStudios = [] as string[];
   const allStudios = await Studio.getAll();
 
   allStudios.forEach(studio => {
-    if (perms.includes(studio.name.toLowerCase())) {
+    if (stripStr(str).includes(stripStr(studio.name))) {
       foundStudios.push(studio._id);
     }
   });

--- a/src/graphql/mutations/actor.ts
+++ b/src/graphql/mutations/actor.ts
@@ -2,7 +2,7 @@ import * as database from "../../database";
 import Actor from "../../types/actor";
 import Scene from "../../types/scene";
 import { Dictionary } from "../../types/utility";
-import { tokenPerms } from "../../extractor";
+import { stripStr } from "../../extractor";
 import * as logger from "../../logger/index";
 import { getConfig } from "../../config/index";
 
@@ -29,11 +29,11 @@ export default {
     }
 
     for (const scene of await Scene.getAll()) {
-      const perms = tokenPerms(scene.path || scene.name);
+      const perms = stripStr(scene.path || scene.name);
 
       if (
-        perms.includes(actor.name.toLowerCase()) ||
-        actor.aliases.some(alias => perms.includes(alias.toLowerCase()))
+        perms.includes(stripStr(actor.name)) ||
+        actor.aliases.some(alias => perms.includes(stripStr(alias)))
       ) {
         if (config.APPLY_ACTOR_LABELS === true) {
           const sceneLabels = (await Scene.getLabels(scene)).map(l => l._id);

--- a/src/graphql/mutations/label.ts
+++ b/src/graphql/mutations/label.ts
@@ -4,7 +4,7 @@ import Label from "../../types/label";
 import Scene from "../../types/scene";
 import Image from "../../types/image";
 import { Dictionary } from "../../types/utility";
-import { tokenPerms } from "../../extractor";
+import { stripStr } from "../../extractor";
 import * as logger from "../../logger/index";
 
 type ILabelUpdateOpts = Partial<{
@@ -32,11 +32,11 @@ export default {
     const label = new Label(args.name, args.aliases);
 
     for (const scene of await Scene.getAll()) {
-      const perms = tokenPerms(scene.path || scene.name);
+      const perms = stripStr(scene.path || scene.name);
 
       if (
-        perms.includes(label.name.toLowerCase()) ||
-        label.aliases.some(alias => perms.includes(alias.toLowerCase()))
+        perms.includes(stripStr(label.name)) ||
+        label.aliases.some(alias => perms.includes(stripStr(alias)))
       ) {
         const labels = (await Scene.getLabels(scene)).map(l => l._id);
         labels.push(label._id);

--- a/src/graphql/mutations/studio.ts
+++ b/src/graphql/mutations/studio.ts
@@ -3,7 +3,7 @@ import Studio from "../../types/studio";
 import Scene from "../../types/scene";
 import Movie from "../../types/movie";
 import Image from "../../types/image";
-import { tokenPerms } from "../../extractor";
+import { stripStr } from "../../extractor";
 import * as logger from "../../logger/index";
 import { getConfig } from "../../config/index";
 
@@ -22,9 +22,9 @@ export default {
     const studio = new Studio(name);
 
     for (const scene of await Scene.getAll()) {
-      const perms = tokenPerms(scene.path || scene.name);
+      const perms = stripStr(scene.path || scene.name);
 
-      if (scene.studio === null && perms.includes(studio.name.toLowerCase())) {
+      if (scene.studio === null && perms.includes(stripStr(studio.name))) {
         await database.update(
           database.store.scenes,
           { _id: scene._id },

--- a/src/queue/index.ts
+++ b/src/queue/index.ts
@@ -259,8 +259,8 @@ class Queue {
           await this.process(head);
         } catch (error) {
           logger.warn("Error processing scene:", error.message);
-          await database.remove(this.store, { _id: head._id });
         }
+        await database.remove(this.store, { _id: head._id });
         head = await this.getFirst();
       }
       logger.success("Processing done");


### PR DESCRIPTION
Improve matching algorithm by stripping and ignoring all whitespaces for actors/labels/studio
Also fixed queue/index.ts processLoop

Previously, if we have "Actor Name" (with a space between words), it wouldn't match a filename called xxxActorNamexxx. Now it would.

This would fix https://github.com/boi123212321/porn-manager/issues/198 and a bug introduced by https://github.com/boi123212321/porn-manager/issues/189 