### PR TITLE
Only show Labels applicable to side

### DIFF
--- a/app/src/views/Actors.vue
+++ b/app/src/views/Actors.vue
@@ -550,7 +550,7 @@ export default class SceneList extends mixins(DrawerMixin) {
     ApolloClient.query({
       query: gql`
         {
-          getLabels {
+          getAreaLabels(idfront: "ac_") {
             _id
             name
             aliases

--- a/app/src/views/Actors.vue
+++ b/app/src/views/Actors.vue
@@ -559,7 +559,7 @@ export default class SceneList extends mixins(DrawerMixin) {
       `
     })
       .then(res => {
-        this.allLabels = res.data.getLabels;
+        this.allLabels = res.data.getAreaLabels;
       })
       .catch(err => {
         console.error(err);

--- a/app/src/views/Images.vue
+++ b/app/src/views/Images.vue
@@ -445,7 +445,7 @@ export default class ImagesView extends mixins(DrawerMixin) {
     ApolloClient.query({
       query: gql`
         {
-          getLabels {
+          getAreaLabels(idfront: "im_") {
             _id
             name
           }

--- a/app/src/views/Images.vue
+++ b/app/src/views/Images.vue
@@ -453,7 +453,7 @@ export default class ImagesView extends mixins(DrawerMixin) {
       `
     })
       .then(res => {
-        this.allLabels = res.data.getLabels;
+        this.allLabels = res.data.getAreaLabels;
       })
       .catch(err => {
         console.error(err);

--- a/app/src/views/Movies.vue
+++ b/app/src/views/Movies.vue
@@ -509,7 +509,7 @@ export default class MovieList extends mixins(DrawerMixin) {
     ApolloClient.query({
       query: gql`
         {
-          getLabels {
+          getAreaLabels(idfront: "mo_") {
             _id
             name
             aliases

--- a/app/src/views/Movies.vue
+++ b/app/src/views/Movies.vue
@@ -518,7 +518,7 @@ export default class MovieList extends mixins(DrawerMixin) {
       `
     })
       .then(res => {
-        this.allLabels = res.data.getLabels;
+        this.allLabels = res.data.getAreaLabels;
       })
       .catch(err => {
         console.error(err);

--- a/app/src/views/Scenes.vue
+++ b/app/src/views/Scenes.vue
@@ -684,7 +684,7 @@ export default class SceneList extends mixins(DrawerMixin) {
     ApolloClient.query({
       query: gql`
         {
-          getLabels {
+          getAreaLabels(idfront: "sc_") {
             _id
             name
             aliases

--- a/app/src/views/Scenes.vue
+++ b/app/src/views/Scenes.vue
@@ -693,7 +693,7 @@ export default class SceneList extends mixins(DrawerMixin) {
       `
     })
       .then(res => {
-        this.allLabels = res.data.getLabels;
+        this.allLabels = res.data.getAreaLabels;
       })
       .catch(err => {
         console.error(err);

--- a/app/src/views/Studios.vue
+++ b/app/src/views/Studios.vue
@@ -436,7 +436,7 @@ export default class StudioList extends mixins(DrawerMixin) {
     ApolloClient.query({
       query: gql`
         {
-          getLabels {
+          getAreaLabels(idfront: "st_") {
             _id
             name
             aliases

--- a/app/src/views/Studios.vue
+++ b/app/src/views/Studios.vue
@@ -445,7 +445,7 @@ export default class StudioList extends mixins(DrawerMixin) {
       `
     })
       .then(res => {
-        this.allLabels = res.data.getLabels;
+        this.allLabels = res.data.getAreaLabels;
       })
       .catch(err => {
         console.error(err);

--- a/src/graphql/resolvers/query.ts
+++ b/src/graphql/resolvers/query.ts
@@ -124,14 +124,32 @@ export default {
     return labels.sort((a, b) => a.name.localeCompare(b.name));
   },
   async getAreaLabels(_, { idfront }: { idfront: string }) {
-    const references = await CrossReference.getAll()
-    var labels = (
-      await mapAsync(
-        references.filter(r => r.to.startsWith("la_")).filter(r => r.from.startsWith(idfront)),
-        r => Label.getById(r.to)
-      )
-    ).filter(Boolean) as Label[];
-    return labels.sort((a, b) => a.name.localeCompare(b.name));
+    switch (idfront) {
+      case "ac_":
+        var table = Actor;
+        break;
+      case "im_":
+        var table = Image;
+        break;
+      case "mo_":
+        var table = Movie;
+        break;
+      case "sc_":
+        var table = Scene;
+        break;
+      case "st_":
+        var table = Studio;
+        break;
+    }
+    
+    const elements = await table.getAll();
+    var element;
+    var labels = [];
+    for (element of elements){
+        labels = labels.concat(await table.getLabels(element));
+    }
+    labels = labels.filter(Boolean) as Label[]
+    return [ ...new Set(labels)].sort((a, b) => a.name.localeCompare(b.name));
   },
   async numScenes() {
     return await database.count(database.store.scenes, {});

--- a/src/graphql/resolvers/query.ts
+++ b/src/graphql/resolvers/query.ts
@@ -2,6 +2,7 @@ import Actor from "../../types/actor";
 import Label from "../../types/label";
 import Scene from "../../types/scene";
 import Movie from "../../types/movie";
+import CrossReference from "../../types/cross_references";
 import { Dictionary, mapAsync } from "../../types/utility";
 import ProcessingQueue from "../../queue/index";
 import Studio from "../../types/studio";
@@ -120,6 +121,16 @@ export default {
   },
   async getLabels() {
     const labels = await Label.getAll();
+    return labels.sort((a, b) => a.name.localeCompare(b.name));
+  },
+  async getAreaLabels(_, { idfront }: { idfront: string }) {
+    const references = await CrossReference.getAll()
+    var labels = (
+      await mapAsync(
+        references.filter(r => r.to.startsWith("la_")).filter(r => r.from.startsWith(idfront)),
+        r => Label.getById(r.to)
+      )
+    ).filter(Boolean) as Label[];
     return labels.sort((a, b) => a.name.localeCompare(b.name));
   },
   async numScenes() {

--- a/src/graphql/resolvers/query.ts
+++ b/src/graphql/resolvers/query.ts
@@ -148,8 +148,7 @@ export default {
     for (element of elements){
         labels = labels.concat(await table.getLabels(element));
     }
-    labels = labels.filter(Boolean);
-    labels = labels.filter((value, index, array) => !array.filter((v, i) => JSON.stringify(value) == JSON.stringify(v) && i < index).length);
+    labels = labels.filter(Boolean).filter((value, index, array) => !array.filter((v, i) => JSON.stringify(value) == JSON.stringify(v) && i < index).length);
 
     return labels.sort((a, b) => a.name.localeCompare(b.name));
   },

--- a/src/graphql/resolvers/query.ts
+++ b/src/graphql/resolvers/query.ts
@@ -2,7 +2,6 @@ import Actor from "../../types/actor";
 import Label from "../../types/label";
 import Scene from "../../types/scene";
 import Movie from "../../types/movie";
-import CrossReference from "../../types/cross_references";
 import { Dictionary, mapAsync } from "../../types/utility";
 import ProcessingQueue from "../../queue/index";
 import Studio from "../../types/studio";
@@ -124,32 +123,35 @@ export default {
     return labels.sort((a, b) => a.name.localeCompare(b.name));
   },
   async getAreaLabels(_, { idfront }: { idfront: string }) {
+    var table;
     switch (idfront) {
       case "ac_":
-        var table = Actor;
+        table = Actor;
         break;
       case "im_":
-        var table = Image;
+        table = Image;
         break;
       case "mo_":
-        var table = Movie;
+        table = Movie;
         break;
       case "sc_":
-        var table = Scene;
+        table = Scene;
         break;
       case "st_":
-        var table = Studio;
+        table = Studio;
         break;
     }
     
     const elements = await table.getAll();
     var element;
-    var labels = [];
+    var labels : Label[] = [];
     for (element of elements){
         labels = labels.concat(await table.getLabels(element));
     }
-    labels = labels.filter(Boolean) as Label[]
-    return [ ...new Set(labels)].sort((a, b) => a.name.localeCompare(b.name));
+    labels = labels.filter(Boolean);
+    labels = labels.filter((value, index, array) => !array.filter((v, i) => JSON.stringify(value) == JSON.stringify(v) && i < index).length);
+
+    return labels.sort((a, b) => a.name.localeCompare(b.name));
   },
   async numScenes() {
     return await database.count(database.store.scenes, {});

--- a/src/graphql/schema/label.ts
+++ b/src/graphql/schema/label.ts
@@ -4,6 +4,7 @@ export default gql`
   extend type Query {
     numLabels: Int!
     getLabels: [Label!]!
+    getAreaLabels(idfront: String!): [Label]!
     getLabelById(id: String!): Label
   }
 

--- a/src/graphql/schema/label.ts
+++ b/src/graphql/schema/label.ts
@@ -4,7 +4,7 @@ export default gql`
   extend type Query {
     numLabels: Int!
     getLabels: [Label!]!
-    getAreaLabels(idfront: String!): [Label]!
+    getAreaLabels(idfront: String!): [Label!]!
     getLabelById(id: String!): Label
   }
 


### PR DESCRIPTION
Like discussed in #377, I created a fork only showing specific labels for specific pages, like for example brunette may only apply to actors, but not to scenes, presuming scenes do not inherit them. 
If that is the case (or other scenarios regarding images or movies), the label will not show up.

I settled with this on option 2 of what was proposed in the issue, as this will take care of it automatically and it was not that difficult to implement. 

One thing before merging, I was able to get it working with the testserver, but not with the built release. Probably I simply forgot something, but the webinterface was not adjusted (the changes in the vue files). However, the server part is tested compiled and as a test setup, both times working. 

If there are further requirements, addings or thoughts, ask away!