### PR TITLE
added age calculation for performer in scene

### DIFF
--- a/app/src/components/ActorGrid.vue
+++ b/app/src/components/ActorGrid.vue
@@ -11,7 +11,7 @@
                   class="text-none black--text primary"
                   depressed
                 >{{ actor.name }}</v-btn>
-                <div v-if="sceneDate && actor.bornOn" class="py-2 text-center">
+                <div v-if="sceneDate && actor.bornOn" class="mt-2 text-center">
                   <p>{{ calculateAge(actor) }}<span class="caption"> y/o in this scene</span></p>
                 </div>
               </v-overlay>

--- a/app/src/components/ActorGrid.vue
+++ b/app/src/components/ActorGrid.vue
@@ -11,6 +11,9 @@
                   class="text-none black--text primary"
                   depressed
                 >{{ actor.name }}</v-btn>
+                <div v-if="sceneDate && actor.bornOn" class="py-2 text-center">
+                  <p>{{ calculateAge(actor) }}<span class="caption"> y/o in this scene</span></p>
+                </div>
               </v-overlay>
             </v-fade-transition>
           </v-img>
@@ -25,15 +28,23 @@ import { Component, Vue, Prop } from "vue-property-decorator";
 import IActor from "../types/actor";
 import { serverBase } from "../apollo";
 import { contextModule } from "../store/context";
+import moment from 'moment';
 
 @Component
 export default class ActorGrid extends Vue {
   @Prop() value!: IActor[];
+  @Prop() sceneDate?: number;
   @Prop({ default: 6 }) cols!: number;
   @Prop({ default: 6 }) sm!: number;
   @Prop({ default: 6 }) md!: number;
   @Prop({ default: 6 }) lg!: number;
   @Prop({ default: 6 }) xl!: number;
+
+  calculateAge(actor: IActor) {
+    if(actor.bornOn) {
+      return moment(this.sceneDate).diff(actor.bornOn, 'years');
+    }
+  }
 
   thumbnail(actor: IActor) {
     if (actor.thumbnail)

--- a/app/src/components/ActorGrid.vue
+++ b/app/src/components/ActorGrid.vue
@@ -1,24 +1,19 @@
 <template>
   <v-row dense>
     <v-col :cols="cols" :sm="sm" :md="md" :lg="lg" :xl="xl" v-for="actor in value" :key="actor._id">
-      <v-hover>
-        <template v-slot:default="{ hover }">
-          <v-img height="100%" cover :src="thumbnail(actor)">
-            <v-fade-transition>
-              <v-overlay v-if="hover" absolute color="primary">
-                <v-btn
-                  :to="`/actor/${actor._id}`"
-                  class="text-none black--text primary"
-                  depressed
-                >{{ actor.name }}</v-btn>
-                <div v-if="sceneDate && actor.bornOn" class="mt-2 text-center">
-                  <p>{{ calculateAge(actor) }}<span class="caption"> y/o in this scene</span></p>
-                </div>
-              </v-overlay>
-            </v-fade-transition>
-          </v-img>
-        </template>
-      </v-hover>
+      <router-link :to="`/actor/${actor._id}`">
+        <v-img v-ripple height="100%" cover :src="thumbnail(actor)">
+          <v-fade-transition>
+            <div class="white--text med--text py-1 bottom-bar text-center">
+              <div class="font-weight-bold">{{ actor.name }}</div>
+              <div v-if="sceneDate && actor.bornOn" class="text-center body-2">
+                <div class="mr-1 d-inline-block font-weight-bold">{{ calculateAge(actor) }}</div>
+                <div class="d-inline-block caption">y/o in this scene</div>
+              </div>
+            </div>
+          </v-fade-transition>
+        </v-img>
+      </router-link>
     </v-col>
   </v-row>
 </template>
@@ -28,7 +23,7 @@ import { Component, Vue, Prop } from "vue-property-decorator";
 import IActor from "../types/actor";
 import { serverBase } from "../apollo";
 import { contextModule } from "../store/context";
-import moment from 'moment';
+import moment from "moment";
 
 @Component
 export default class ActorGrid extends Vue {
@@ -41,8 +36,8 @@ export default class ActorGrid extends Vue {
   @Prop({ default: 6 }) xl!: number;
 
   calculateAge(actor: IActor) {
-    if(actor.bornOn) {
-      return moment(this.sceneDate).diff(actor.bornOn, 'years');
+    if (actor.bornOn) {
+      return moment(this.sceneDate).diff(actor.bornOn, "years");
     }
   }
 
@@ -57,4 +52,12 @@ export default class ActorGrid extends Vue {
 </script>
 
 <style lang="scss" scoped>
+.bottom-bar {
+  left: 4px;
+  right: 4px;
+  border-radius: 8px;
+  position: absolute;
+  background: black;
+  bottom: 4px;
+}
 </style>

--- a/app/src/views/SceneDetails.vue
+++ b/app/src/views/SceneDetails.vue
@@ -199,7 +199,7 @@
         <v-col cols="12" sm="6">
           <h1 class="font-weight-light text-center">Starring</h1>
 
-          <ActorGrid :cols="6" :sm="6" :md="4" :lg="4" :xl="3" :value="actors" />
+          <ActorGrid :cols="6" :sm="6" :md="4" :lg="4" :xl="3" :value="actors" :sceneDate="currentScene.releaseDate"/>
 
           <!-- <v-row>
             <v-col


### PR DESCRIPTION
The age of the performer is calculated with the release date of the scene. So the calculated age is the exact difference to the release date. This is a suggestion for #404 

I've added a text field containing the calculated age when hovering over the actor card. If the scene has no release date or the actor has no birth date, the age will not be calculated. 

**Example**: 
Katana Kombat has a birth date set and the scene has a release date. The paragraph with her age in this scene will be shown on the actor card. (Note: I've replaced her profile picture with the green background).
![v](https://user-images.githubusercontent.com/61378413/76692043-4426d080-6651-11ea-869d-ee083ed05a81.png)


**Example No. 2**: 
John Doe has no birth date set and because of that, his age will not be calculated and not be shown.
![no-age](https://user-images.githubusercontent.com/61378413/76691083-27859b00-6647-11ea-8ea3-c0814000b892.png)


