### PR TITLE
Support for actor plugins to add images

### DIFF
--- a/src/plugin_events/actor.ts
+++ b/src/plugin_events/actor.ts
@@ -65,6 +65,27 @@ export async function onActorCreate(
   )
     actor.thumbnail = pluginResult.thumbnail;
 
+  if (
+    typeof pluginResult.hero == "string" &&
+    pluginResult.hero.startsWith("im_") &&
+    !actor.hero
+  )
+    actor.hero = pluginResult.hero;
+
+  if (
+    typeof pluginResult.altThumbnail == "string" &&
+    pluginResult.altThumbnail.startsWith("im_") &&
+    !actor.altThumbnail
+  )
+    actor.altThumbnail = pluginResult.altThumbnail;
+
+  if (
+    typeof pluginResult.avatar == "string" &&
+    pluginResult.avatar.startsWith("im_") &&
+    !actor.avatar
+  )
+    actor.avatar = pluginResult.avatar;
+
   if (typeof pluginResult.name === "string") actor.name = pluginResult.name;
 
   if (typeof pluginResult.description === "string")


### PR DESCRIPTION
Discovered this project a few weeks ago and love using it. Adding some more love here.

The changes allow actor plugins to set and persist hero, altThumbnail and avatar images.
A plugin that takes advantage of this change to populate actor images and aliases [is also submitted in a pull request](https://github.com/boi123212321/porn-manager-plugins/pull/1/).

